### PR TITLE
[PRO-2848] - Fixing password incorrect banner bug

### DIFF
--- a/mikoba/UI/Components/PINInput.xaml.cs
+++ b/mikoba/UI/Components/PINInput.xaml.cs
@@ -95,7 +95,7 @@ namespace mikoba.UI.Components
 
         public void SubmitPIN(object sender, TextChangedEventArgs e)
         {
-            if (FinishCommand != null)
+            if (FinishCommand != null && !String.IsNullOrEmpty(e.NewTextValue))
             {
                 if (FinishCommand.CanExecute(FinishCommandParameter))
                 {


### PR DESCRIPTION
The `Login` command was running when the PIN login screen was rendering, which meant that we initially showed the "Password Incorrect" banner because when you first hit the screen your password is, indeed, incorrect.

Adding a condition to suppress the command if the final text field is empty, because you shouldn't be able to log in anyways if you haven't added text to the final text field.